### PR TITLE
Changed serializer for json to Newtonsoft

### DIFF
--- a/WebCall/Interfaces/IJsonSerializer.cs
+++ b/WebCall/Interfaces/IJsonSerializer.cs
@@ -1,0 +1,10 @@
+﻿using RestSharp.Deserializers;
+using RestSharp.Serializers;
+
+namespace WebCall.Interfaces
+{
+    public interface IJsonSerializer : ISerializer, IDeserializer
+    {
+        
+    }
+}

--- a/WebCall/Interfaces/IWebCallService.cs
+++ b/WebCall/Interfaces/IWebCallService.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using RestSharp;
+
+namespace WebCall.Interfaces
+{
+    public interface IWebCallService
+    {
+        TResponse Invoke<TResponse>(Uri endpointUri, Method method = Method.POST, string contentType = "application/x-www-form-urlencoded", Dictionary<WebCallHeaderType, string> customHeaders = null)
+            where TResponse : new();
+
+        TResponse Invoke<TRequest, TResponse>(TRequest request, Uri endpointUri,
+            Method method = Method.POST,
+            string contentType = "application/x-www-form-urlencoded", Dictionary<WebCallHeaderType, string> customHeaders = null)
+            where TResponse : new();
+    }
+}

--- a/WebCall/Interfaces/NewtonsoftJsonSerializer.cs
+++ b/WebCall/Interfaces/NewtonsoftJsonSerializer.cs
@@ -1,0 +1,66 @@
+﻿using System.IO;
+using Newtonsoft.Json;
+
+namespace WebCall.Interfaces
+{
+    public class NewtonsoftJsonSerializer : IJsonSerializer
+    {
+        // Borrowed from http://bytefish.de/blog/restsharp_custom_json_serializer/
+
+        private readonly JsonSerializer _serializer;
+
+        public NewtonsoftJsonSerializer(JsonSerializer serializer)
+        {
+            _serializer = serializer;
+        }
+
+        public string ContentType
+        {
+            get { return "application/json"; } // Probably used for Serialization?
+            set { }
+        }
+
+        public string DateFormat { get; set; }
+
+        public string Namespace { get; set; }
+
+        public string RootElement { get; set; }
+
+        public string Serialize(object obj)
+        {
+            using (var stringWriter = new StringWriter())
+            {
+                using (var jsonTextWriter = new JsonTextWriter(stringWriter))
+                {
+                    _serializer.Serialize(jsonTextWriter, obj);
+
+                    return stringWriter.ToString();
+                }
+            }
+        }
+
+        public T Deserialize<T>(RestSharp.IRestResponse response)
+        {
+            var content = response.Content;
+
+            using (var stringReader = new StringReader(content))
+            {
+                using (var jsonTextReader = new JsonTextReader(stringReader))
+                {
+                    return _serializer.Deserialize<T>(jsonTextReader);
+                }
+            }
+        }
+
+        public static NewtonsoftJsonSerializer Default
+        {
+            get
+            {
+                return new NewtonsoftJsonSerializer(new JsonSerializer()
+                {
+                    NullValueHandling = NullValueHandling.Ignore,
+                });
+            }
+        }
+    }
+}

--- a/WebCall/WebCall.csproj
+++ b/WebCall/WebCall.csproj
@@ -34,6 +34,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.105.2.3\lib\net452\RestSharp.dll</HintPath>
       <Private>True</Private>
@@ -48,6 +52,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Interfaces\IJsonSerializer.cs" />
+    <Compile Include="Interfaces\IWebCallService.cs" />
+    <Compile Include="Interfaces\NewtonsoftJsonSerializer.cs" />
     <Compile Include="IWebCallService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="WebCallHeaderType.cs" />

--- a/WebCall/packages.config
+++ b/WebCall/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Newtonsoft.Json" version="10.0.1" targetFramework="net452" />
   <package id="RestSharp" version="105.2.3" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Overrode default serializer for RestSharp, replacing it with Newtonsoft if the content type is any of the following.

- "application/json"
- "text/json"
- "text/x-json"
- "text/javascript"
- "*+json"